### PR TITLE
Turn off ESLint propTypes missing warning

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,6 +33,7 @@ export default [
         "warn",
         { allowConstantExport: true },
       ],
+      "react-prop-types": false,
     },
   },
 ];


### PR DESCRIPTION
No longer supported